### PR TITLE
fix: incorrect link for powershell install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Without guessing, this is the most important step in using CLI. You can install 
 
 ### Windows (Powershell)
 ```powershell
-irm https://openbin.dev/install.ps1 | iex
+irm https://www.openbin.dev/install.ps1 | iex
 ```
 
 ### Linux and macOS

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Without guessing, this is the most important step in using CLI. You can install 
 
 ### Windows (Powershell)
 ```powershell
-irm https://www.openbin.dev/install.ps1 | iex
+irm https://openbin.dev/install.ps1 | iex
 ```
+**Requires at least v7.4.0-preview.2 of PowerShell ([view here](https://github.com/PowerShell/PowerShell/releases/tag/v7.4.0-preview.2))**
 
 ### Linux and macOS
 ```shell

--- a/web/src/components/terminal.tsx
+++ b/web/src/components/terminal.tsx
@@ -17,7 +17,7 @@ function getLines(os: string) {
     {
       text: `${
         os === "windows"
-          ? "irm https://www.openbin.dev/install.ps1 | iex"
+          ? "irm https://openbin.dev/install.ps1 | iex"
           : "curl -fsSL https://openbin.dev/install.sh | sh"
       }`,
       cmd: true,

--- a/web/src/components/terminal.tsx
+++ b/web/src/components/terminal.tsx
@@ -17,7 +17,7 @@ function getLines(os: string) {
     {
       text: `${
         os === "windows"
-          ? "irm https://openbin.dev/install.ps1 | iex"
+          ? "irm https://www.openbin.dev/install.ps1 | iex"
           : "curl -fsSL https://openbin.dev/install.sh | sh"
       }`,
       cmd: true,


### PR DESCRIPTION
Using the command without `www` results in a Permanent Redirect error:
```
irm : The remote server returned an error: (308) Permanent Redirect.
At line:1 char:1
+ irm https://openbin.dev/install.ps1 | iex
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-RestMethod], WebExc
   eption
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
```